### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/sensors/volumeSensing/ConeSensorComponent.java
+++ b/src/main/java/org/terasology/sensors/volumeSensing/ConeSensorComponent.java
@@ -12,7 +12,7 @@ public class ConeSensorComponent implements Component<ConeSensorComponent> {
     /**
      * The aperture of the cone, defined in degrees.
      */
-    float aperture = 60.0f;
+    public float aperture = 60.0f;
 
     @Override
     public void copyFrom(ConeSensorComponent other) {


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191